### PR TITLE
Add daily reminders for meetups happening today

### DIFF
--- a/.github/workflows/push-events-daily.yml
+++ b/.github/workflows/push-events-daily.yml
@@ -1,0 +1,24 @@
+name: "Push events daily"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15 * * *'
+
+jobs:
+  syndicate:
+    name: "Post events"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Check out repository"
+      uses: actions/checkout@v3
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - run: bundle exec ruby main.rb --destinations=TD
+      env:
+        SYN_ENV: production
+        TD_SLACK_WEBHOOK: ${{ secrets.TD_SLACK_WEBHOOK }}

--- a/slack.rb
+++ b/slack.rb
@@ -17,9 +17,10 @@ class Slack
     @message = []
   end
 
-  def self.syndicate(events, dry_run)
+  def self.syndicate(events, announcement_type, dry_run)
     return if events.empty?
 
+    @announcement_type = announcement_type
     @payload = payload(events)
 
     if dry_run
@@ -30,12 +31,19 @@ class Slack
   end
 
   def self.payload(events)
+    if @announcement_type == 'weekly'
+      header_text = ":balloon: Upcoming Events"
+    elsif @announcement_type == 'daily'
+      header_text = ":earth_americas: Happening Today"
+    else
+      header_text = ":loudspeaker: Happening Soon"
+    end
     header = [
       {
-        type: "section",
+        type: "header",
         text: {
-          type: "mrkdwn",
-          text: ":balloon: Upcoming events:"
+          type: "plain_text",
+          text: header_text,
         }
       },
       {
@@ -44,6 +52,7 @@ class Slack
     ]
 
     footer = [
+      { type: "divider" },
       {
         type: "actions",
         elements: [
@@ -91,7 +100,13 @@ class Slack
       }
     ]
 
-    [header, events.reduce([], :concat), footer].reduce([], :concat)
+    elements = [header, events.reduce([], :concat)]
+    puts @announcement_type
+    if @announcement_type == 'weekly'
+      elements << footer
+    end
+    
+    elements.reduce([], :concat)
   end
 
   def self.message_json
@@ -103,7 +118,7 @@ class Slack
   def self.post
     return if @payload.length == 0
 
-    targets = [ENV["TD_SLACK_WEBHOOK"], ENV["TBT_SLACK_WEBHOOK"], ENV["TBUX_SLACK_WEBHOOK"]]
+    targets = [ENV["TD_SLACK_WEBHOOK"]]
 
     targets.each do |t|
       uri = URI.parse(t)

--- a/slack.rb
+++ b/slack.rb
@@ -32,7 +32,7 @@ class Slack
 
   def self.payload(events)
     if @announcement_type == 'weekly'
-      header_text = ":balloon: Upcoming Events"
+      header_text = ":balloon: Happening This Week"
     elsif @announcement_type == 'daily'
       header_text = ":earth_americas: Happening Today"
     else
@@ -101,7 +101,6 @@ class Slack
     ]
 
     elements = [header, events.reduce([], :concat)]
-    puts @announcement_type
     if @announcement_type == 'weekly'
       elements << footer
     end


### PR DESCRIPTION
This PR adds the capability to post daily reminders for meetup events happening today to slack:

## Daily reminders

<img width="623" alt="image" src="https://github.com/user-attachments/assets/94fa3d05-273f-4e7e-9d20-4b9e50b8fb49">

Fixes https://github.com/TampaDevs/events-slack-push/issues/1

## Extra

It also adds the capability to replace the houly 60 minute event reminders in the Tampa Devs slack that are currently going to `#meetup-reminders` to address https://github.com/TampaDevs/events-slack-push/issues/4 (though actually replacing those are outside of the scope of this PR), and makes some small tweaks to the weekly event reminders (like posting events happening just this week instead of two weeks out).

The `main.rb` script would now be invoked as `ruby main.rb [--daily|--hourly|--weekly]`. By default `ruby main.rb` with no arguments defaults to `main.rb --weekly` as to maintain backwards compatibility with how the script is currently being invoked.