### PR TITLE
Add daily reminders for meetups happening today

### DIFF
--- a/.github/workflows/push-events-daily.yml
+++ b/.github/workflows/push-events-daily.yml
@@ -1,0 +1,24 @@
+name: "Push events daily"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '5 15 * * *'
+
+jobs:
+  syndicate:
+    name: "Post events"
+    runs-on: self-hosted
+
+    steps:
+    - name: "Check out repository"
+      uses: actions/checkout@v3
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - run: bundle exec ruby main.rb --destinations=TD
+      env:
+        SYN_ENV: production
+        TD_SLACK_WEBHOOK: ${{ secrets.TD_SLACK_WEBHOOK }}

--- a/event.rb
+++ b/event.rb
@@ -20,16 +20,8 @@ class MeetupEvent
     parts.join(", ") + " long"
   end
 
-  def self.within_next_two_weeks?(date_string)
-    date = Date.parse(date_string)
-    today = Date.today
-    date >= today && date <= (today + 14)
-  end
-
   def self.format_slack(group)
     return if group["unifiedEvents"]["count"] == 0
-
-    return unless within_next_two_weeks?(group["unifiedEvents"]["edges"][0]["node"]["dateTime"])
 
     event_blocks = [{
       type: "section",
@@ -57,12 +49,10 @@ class MeetupEvent
           }
         ]
       },
-      {
-        type: "divider"
-      }]
+    ]
 
     if group["name"] == "Tampa Devs"
-      event_blocks[0][:text][:text].prepend(":tampadevs: ")
+      event_blocks[0][:text][:text] = ":tampadevs:" + " " + event_blocks[0][:text][:text]
     end
 
     if group["unifiedEvents"]["edges"][0]["node"]["venue"]

--- a/main.rb
+++ b/main.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "net/http"
+require 'optparse'
 require_relative "event"
 require_relative "slack"
 
@@ -12,8 +13,18 @@ class EventSyndicator
     @dry_run = ENV["SYN_ENV"] != "production"
   end
 
-  def fetch
-    groups = JSON.parse(Net::HTTP.get(URI("https://events.api.tampa.dev/")))
+  def fetch(announcement_type, destinations)
+
+    events_url = case announcement_type
+      when :weekly
+        'https://events.api.tampa.dev?within_days=7'
+      when :daily
+        'https://events.api.tampa.dev?within_hours=24'
+      when :hourly
+        'https://events.api.tampa.dev?within_hours=1'
+    end
+
+    groups = JSON.parse(Net::HTTP.get(URI(events_url)))
 
     sorted_events = []
     formatted_events = []
@@ -31,14 +42,48 @@ class EventSyndicator
       formatted_events << event unless event.nil?
     end
 
+    # fencepost
+    formatted_events[0...-1].each do |element|
+      element << { type: "divider" }
+    end
+
     if formatted_events.empty?
       puts "No events to post, exiting with nothing to do."
       exit
     end
 
-    Slack.syndicate(formatted_events, @dry_run)
+    Slack.syndicate(formatted_events, announcement_type, destinations, @dry_run)
   end
 end
 
-syn = EventSyndicator.new
-syn.fetch
+def main
+  options = {}
+  OptionParser.new do |opts|
+    opts.banner = "Usage: main.rb [options]"
+
+    # Boolean argument for --daily, --hourly, or --weekly
+    announcement_types = [:daily, :hourly, :weekly]
+    opts.on("--daily", "Set announcement type to daily") do
+      options[:announcement_type] = :daily
+    end
+    opts.on("--hourly", "Set announcement type to hourly") do
+      options[:announcement_type] = :hourly
+    end
+    opts.on("--weekly", "Set announcement type to weekly") do
+      options[:announcement_type] = :weekly
+    end
+
+    # Argument for --destinations=<destinations>
+    opts.on("--destinations=DESTINATIONS", "Comma-separated list of destinations") do |destinations|
+      options[:destinations] = destinations.split(',')
+    end
+  end.parse!
+
+  announcement_type = options[:announcement_type] || :weekly
+  destinations = options[:destinations] || ['TD', 'TBT', 'TBUX']
+
+  syn = EventSyndicator.new
+  syn.fetch(announcement_type, destinations)
+end
+
+main


### PR DESCRIPTION
This PR adds the capability to post daily reminders for meetup events happening today to slack:

## Daily reminders

<img width="623" alt="image" src="https://github.com/user-attachments/assets/94fa3d05-273f-4e7e-9d20-4b9e50b8fb49">

Fixes https://github.com/TampaDevs/events-slack-push/issues/1

## Additional

It also adds the capability to replace the houly 60 minute event reminders in the Tampa Devs slack that are currently going to `#meetup-reminders` to address https://github.com/TampaDevs/events-slack-push/issues/4 (though actually replacing those are outside of the scope of this PR), and makes some small tweaks to the weekly event reminders (like posting events happening just this week instead of two weeks out).

## Usage

The `main.rb` script would now be invoked as `ruby main.rb [--destinations=<destinations>] [--weekly|--daily |--hourly]` (e.g. `ruby main.rb --destinations=TD --daily` to post today's events to just the Tampa Devs slack). By default, `ruby main.rb` with no arguments defaults to `main.rb --destinations=TD,TBT,TBUX --weekly` as to maintain backwards compatibility with how the script is currently being invoked.

The new workflow `push-events-daily.yml` posts events daily.