### PR TITLE
Move workflow to GitHub-hosted runner

### DIFF
--- a/.github/workflows/push-events.yml
+++ b/.github/workflows/push-events.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   syndicate:
     name: "Post events"
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: "Check out repository"


### PR DESCRIPTION
This PR changes the workflow from running on a self-hosted runner to a GitHub-hosted runner

Fixes https://github.com/TampaDevs/events-slack-push/issues/9

## Note

We're probably using a self-hosted runner for a reason I'm not aware of, so this likely isn't the change we want to make. But it does allow the workflow to run (tested on my fork).